### PR TITLE
fix github and linkedin links

### DIFF
--- a/docs/_data/social-media.yml
+++ b/docs/_data/social-media.yml
@@ -22,7 +22,7 @@ facebook:
   color : 3b5998
 
 github:
-  url   : https://www.github.com/079035
+  url   : https://www.github.com/
   icon  : fab fa-github
   color : 333333
 
@@ -42,7 +42,7 @@ kaggle:
   color : 20beff
 
 linkedin:
-  url   : https://www.linkedin.com/in/~jordi
+  url   : https://www.linkedin.com/in/
   icon  : fab fa-linkedin-in
   color : 007bb5
 


### PR DESCRIPTION
Currently the links to your github and linkedin in the footer of the page are as follow
 - https://www.github.com/079035079035
 - https://www.linkedin.com/in/~jordi~jordi

I think this is because you have modified the theme to include the usernames (and also included the names in your config.

Now the links are:
- https://www.github.com/079035
- https://www.linkedin.com/in/~jordi

Should be a simple fix.